### PR TITLE
Allow for toggling of readonly via indicator

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ The indicator is automatically updated. You don't need to do anything.
 
 * Set what to do when the Status Bar indicator is clicked
     ```json
-    "fileAccess.indicatorAction": "choose" // or simple
+    "fileAccess.indicatorAction": "choose" // or "toggle"
     ```
 
 ## Support

--- a/README.md
+++ b/README.md
@@ -34,6 +34,11 @@ The indicator is automatically updated. You don't need to do anything.
     "fileAccess.uiMode": "complete" // or "simple"
     ```
 
+* Set what to do when the Status Bar indicator is clicked
+    ```json
+    "fileAccess.indicatorAction": "choose" // or simple
+    ```
+
 ## Support
 
 While **Status Bar Read-only Indicator** is free and open source, if you find it useful, please consider supporting it.

--- a/package.json
+++ b/package.json
@@ -64,6 +64,15 @@
 						"complete",
 						"simple"
 					]
+				},
+				"fileAccess.indicatorAction": {
+					"type": "string",
+					"default": "choose",
+					"description": "Sets what action to take when the indicator is clicked",
+					"enum": [
+						"toggle",
+						"choose"
+					]
 				}
 			}
 		}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -90,6 +90,27 @@ export function activate(ctx: ExtensionContext) {
             }
         });
     }
+
+    function indicatorAction() {
+        let action = workspace.getConfiguration("fileAccess").get("indicatorAction");
+        switch (action) {
+            case "toggle":
+                if (readOnlyIndicator.isReadOnly(window.activeTextEditor.document)) {
+                    updateFileAccess("-R");
+                } else {
+                    updateFileAccess("+R");
+                }
+                break;
+
+            case "choose":
+                changeFileAccess();
+                break;
+
+            default:
+                console.log(`Received bad action '${action}'`);
+                window.showErrorMessage(`No indicator action '${action}' is available`);
+        }
+    }
     
     commands.registerCommand("readOnly.makeWriteable", () => {        
         updateFileAccess("-R");
@@ -101,6 +122,10 @@ export function activate(ctx: ExtensionContext) {
     
     commands.registerCommand("readOnly.changeFileAccess", () => {
         changeFileAccess();
+    });
+
+    commands.registerCommand("readOnly.indicatorAction", () => {
+        indicatorAction();
     });
 }
 
@@ -126,7 +151,7 @@ export class ReadOnlyIndicator {
         // Create as needed
         if (!this.statusBarItem) {
             this.statusBarItem = window.createStatusBarItem(location);
-            this.statusBarItem.command = "readOnly.changeFileAccess";
+            this.statusBarItem.command = "readOnly.indicatorAction";
         } 
 
         // Get the current text editor


### PR DESCRIPTION
This pull request addresses the request in Issue #10 by adding a new configuration to the extension. This configuration, defaulted to 'choose' for existing functionality, will change the Read-only Indicator click to switch a file's state from its current one rather than asking what to change it to.

To do this, a new command was registered to handle all actions when the indicator is clicked. This can then be delegated to any other functionality based on the configuration.