### PR TITLE
Add configurable colors.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules
 .vscode-test
 npm-debug.log
 dist
+**/*.vsix

--- a/.vscodeignore
+++ b/.vscodeignore
@@ -14,4 +14,3 @@ tslint.json
 npm-debug.log
 package-lock.json
 webpack.config.js
-**/.history/**

--- a/.vscodeignore
+++ b/.vscodeignore
@@ -14,3 +14,4 @@ tslint.json
 npm-debug.log
 package-lock.json
 webpack.config.js
+**/.history/**

--- a/README.md
+++ b/README.md
@@ -58,9 +58,29 @@ Writeable |![Writeable](images/screenshot-writeable.png)
     "fileAccess.uiMode": "complete" // or "simple"
     ```
 
+* Hides the Status Bar indicator when the file is Writable
+    ```json
+    "fileAccess.hideWhenWritable": true // or false
+    ```
+
+
 * Set what to do when the Status Bar indicator is clicked
     ```json
     "fileAccess.indicatorAction": "choose" // or "toggle"
+    ```
+
+## Available colors
+
+For more information about customizing colors in VSCode, see [Theme Color](https://code.visualstudio.com/api/references/theme-color).
+
+* Sets the Status Bar indicator text color when the file is Read Only
+    ```json
+    "fileAccess.readonlyForeground": "#ff7fc0",
+    ```
+
+* Sets the Status Bar indicator text color when the file is Writable
+    ```json
+    "fileAccess.writableForeground": "#7fcc7f",
     ```
 
 # License

--- a/package.json
+++ b/package.json
@@ -69,6 +69,16 @@
 						"simple"
 					]
 				},
+				"fileAccess.readonlyColor": {
+					"type": "string",
+					"default": "none",
+					"description": "Overrides the Status Bar indicator text color when the file is Read Only"
+				},
+				"fileAccess.writableColor": {
+					"type": "string",
+					"default": "none",
+					"description": "Overrides the Status Bar indicator text color when the file is Writable"
+				},
 				"fileAccess.indicatorAction": {
 					"type": "string",
 					"default": "choose",

--- a/package.json
+++ b/package.json
@@ -69,6 +69,11 @@
 						"simple"
 					]
 				},
+				"fileAccess.hideWhenWritable": {
+					"type": "boolean",
+					"default": false,
+					"description": "Hide the Status Bar indicator when the file is Writable"
+				},
 				"fileAccess.readonlyColor": {
 					"type": "string",
 					"default": "none",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,26 @@
 	],
 	"main": "./dist/extension",
 	"contributes": {
+		"colors": [
+			{
+				"id": "fileAccess.readonlyForeground",
+				"description": "Color for Read Only indicator in the status bar",
+				"defaults": {
+					"dark": "statusBar.foreground",
+					"light": "statusBar.foreground",
+					"highContrast": "statusBar.foreground"
+				}
+			},
+			{
+				"id": "fileAccess.writableForeground",
+				"description": "Color for Writable indicator in the status bar",
+				"defaults": {
+					"dark": "statusBar.foreground",
+					"light": "statusBar.foreground",
+					"highContrast": "statusBar.foreground"
+				}
+			}
+		],
 		"commands": [
 			{
 				"command": "readOnly.makeWriteable",
@@ -73,16 +93,6 @@
 					"type": "boolean",
 					"default": false,
 					"description": "Hide the Status Bar indicator when the file is Writable"
-				},
-				"fileAccess.readonlyColor": {
-					"type": "string",
-					"default": "none",
-					"description": "Overrides the Status Bar indicator text color when the file is Read Only"
-				},
-				"fileAccess.writableColor": {
-					"type": "string",
-					"default": "none",
-					"description": "Overrides the Status Bar indicator text color when the file is Writable"
 				},
 				"fileAccess.indicatorAction": {
 					"type": "string",

--- a/src/statusBar/controller.ts
+++ b/src/statusBar/controller.ts
@@ -12,6 +12,8 @@ export class Controller {
     private statusBar: StatusBar;
     private disposable: Disposable;
 
+    private timeout: NodeJS.Timeout | null;
+
     constructor() {
         this.statusBar = new StatusBar();
         this.statusBar.update();
@@ -33,6 +35,16 @@ export class Controller {
                 this.updateStatusBar();
             }
         }, null, Container.context.subscriptions);
+
+        workspace.onWillSaveTextDocument(e => {
+            const local = this.timeout;
+            if (local) {
+                clearTimeout(local);
+            }
+            this.timeout = setTimeout(() => {
+                this.statusBar.update();
+            }, 50);
+        });
     }
 
     public dispose() {

--- a/src/statusBar/controller.ts
+++ b/src/statusBar/controller.ts
@@ -30,10 +30,9 @@ export class Controller {
                 this.statusBar = undefined;
                 
                 this.statusBar = new StatusBar();
-                this.statusBar.update();
             }
-            if (cfg.affectsConfiguration("fileAccess.uiMode")) {
-                this.updateStatusBar()
+            if (cfg.affectsConfiguration("fileAccess")) {
+                this.updateStatusBar();
             }
         }, null, Container.context.subscriptions);
     }

--- a/src/statusBar/controller.ts
+++ b/src/statusBar/controller.ts
@@ -18,10 +18,8 @@ export class Controller {
 
         Container.context.subscriptions.push(this.statusBar);
 
-        window.onDidChangeActiveTextEditor(editor => {
-            if (editor) {
-                this.statusBar.update();
-            }
+        window.onDidChangeActiveTextEditor(_editor => {
+            this.statusBar.update();
         }, null, Container.context.subscriptions);
 
         workspace.onDidChangeConfiguration(cfg => {

--- a/src/statusBar/statusBar.ts
+++ b/src/statusBar/statusBar.ts
@@ -39,12 +39,17 @@ export class StatusBar {
         const uimodeString: string = (workspace.getConfiguration("fileAccess").get("uiMode", "complete"));
         const uimode: UIMode = uimodeString === "complete" ? UIMode.Complete : UIMode.Simple;
         const readOnly = fileAccess ? fileAccess === FileAccess.ReadOnly : Operations.isReadOnly(activeDocument);
+        const colorConfigString: string = (workspace.getConfiguration("fileAccess").get(readOnly ? "readonlyColor" : "writableColor", "none"));
+        const colorString: string = colorConfigString === "none" || colorConfigString === "" ? "" : colorConfigString;
 
         // Update the status bar
         if (uimode === UIMode.Complete) {
             this.statusBarItem.text = !readOnly ? "$(pencil) [RW]" : "$(circle-slash) [RO]";
         } else {
             this.statusBarItem.text = !readOnly ? "RW" : "RO";
+        }
+        if (colorString != "") {
+            this.statusBarItem.color = colorString;
         }
 
         this.statusBarItem.tooltip = !readOnly ? "The file is writeable" : "The file is read only";

--- a/src/statusBar/statusBar.ts
+++ b/src/statusBar/statusBar.ts
@@ -3,7 +3,7 @@
 *  Licensed under the MIT License. See License.md in the project root for license information.
 *--------------------------------------------------------------------------------------------*/
 
-import { StatusBarAlignment, StatusBarItem, window, workspace } from "vscode";
+import { StatusBarAlignment, StatusBarItem, ThemeColor, window, workspace } from "vscode";
 import { FileAccess, UIMode } from "./../constants";
 import { Operations } from "./../operations";
 export class StatusBar {
@@ -39,8 +39,6 @@ export class StatusBar {
         const uimodeString: string = (workspace.getConfiguration("fileAccess").get("uiMode", "complete"));
         const uimode: UIMode = uimodeString === "complete" ? UIMode.Complete : UIMode.Simple;
         const readOnly = fileAccess ? fileAccess === FileAccess.ReadOnly : Operations.isReadOnly(activeDocument);
-        const colorConfigString: string = (workspace.getConfiguration("fileAccess").get(readOnly ? "readonlyColor" : "writableColor", "none"));
-        const colorString: string = colorConfigString === "none" || colorConfigString === "" ? "" : colorConfigString;
 
         // Update the status bar
         if (uimode === UIMode.Complete) {
@@ -48,9 +46,7 @@ export class StatusBar {
         } else {
             this.statusBarItem.text = !readOnly ? "RW" : "RO";
         }
-        if (colorString != "") {
-            this.statusBarItem.color = colorString;
-        }
+        this.statusBarItem.color = new ThemeColor(readOnly ? "fileAccess.readonlyForeground" : "fileAccess.writableForeground");
 
         this.statusBarItem.tooltip = !readOnly ? "The file is writeable" : "The file is read only";
 

--- a/src/statusBar/statusBar.ts
+++ b/src/statusBar/statusBar.ts
@@ -53,6 +53,13 @@ export class StatusBar {
         }
 
         this.statusBarItem.tooltip = !readOnly ? "The file is writeable" : "The file is read only";
-        this.statusBarItem.show();
+
+        // Show or hide the status bar indicator as appropriate
+        const show = readOnly || !workspace.getConfiguration("fileAccess").get("hideWhenWritable", false);
+        if (show) {
+            this.statusBarItem.show();
+        } else {
+            this.statusBarItem.hide();
+        }
     }
 }


### PR DESCRIPTION
This is a little tweak to allow optional color configuration for the status bar item text for the readonly and writable states.

And I noticed [this feature request](https://github.com/alefragnani/vscode-read-only-indicator/issues/15) and also added that after I make the pull request.  It looks like the pull request is for HEAD, not for the head commit as of when the pull request was make.

(This is my first pull request to contribute to a public repo. Feedback is welcome for how I can improve.)