### PR TITLE
Add command for toggling of readonly

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,14 +43,19 @@ The indicator is automatically updated. You don't need to do anything.
 
 File Access | Status Bar Preview |
 ----------- | ------------------ |
-Read-only |![Read-only](images/screenshot-readonly.png) 
-Writeable |![Writeable](images/screenshot-writeable.png) 
+Read-only |![Read-only](images/screenshot-readonly.png)
+Writeable |![Writeable](images/screenshot-writeable.png)
 
 ## Available commands
 
 * `File Access: Change File Access`
+* `File Access: Toggle File Access`
 * `File Access: Make Read-only`
 * `File Access: Make Writeable`
+
+## Available settings
+
+* `ctrl + shift + a` - `File Access: Toggle File Access`
 
 ## Available settings
 
@@ -82,7 +87,7 @@ For more information about customizing colors in VSCode, see [Theme Color](https
 * Choose the Status Bar indicator text color when the file is Read Only
 ```json
     "workbench.colorCustomizations": {
-      "fileAccess.readonlyForeground": "#ff7fc0",  
+      "fileAccess.readonlyForeground": "#ff7fc0",
     }
 ```
 

--- a/README.md
+++ b/README.md
@@ -55,10 +55,6 @@ Writeable |![Writeable](images/screenshot-writeable.png)
 
 ## Available settings
 
-* `ctrl + shift + a` - `File Access: Toggle File Access`
-
-## Available settings
-
 * Defines the position where the Status Bar indicator is located
     ```json
     "fileAccess.position": "left" // or "right"

--- a/package.json
+++ b/package.json
@@ -74,12 +74,6 @@
 				"title": "File Access: What's New"
 			}
 		],
-		"keybindings": [
-			{
-			  "key": "ctrl+shift+a",
-			  "command": "readOnly.toggleFileAccess"
-			}
-		],
 		"configuration": {
 			"type": "object",
 			"title": "Status Bar Read-Only Indicator Configuration",

--- a/package.json
+++ b/package.json
@@ -71,6 +71,12 @@
 				"title": "File Access: What's New"
 			}
 		],
+		"keybindings": [
+			{
+			  "key": "ctrl+shift+a",
+			  "command": "readOnly.toggleFileAccess"
+			}
+		],
 		"configuration": {
 			"type": "object",
 			"title": "Status Bar Read-Only Indicator Configuration",

--- a/package.json
+++ b/package.json
@@ -63,6 +63,10 @@
 				"title": "File Access: Change File Access"
 			},
 			{
+				"command": "readOnly.toggleFileAccess",
+				"title": "File Access: Toggle File Access"
+			},
+			{
 				"command": "readOnly.whatsNew",
 				"title": "File Access: What's New"
 			}

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -53,8 +53,7 @@ export function registerCommands() {
     }
 
     function toggleFileAccess() {
-        if (!window.activeTextEditor) {
-            window.showInformationMessage("Open a file first to update it attributes");
+        if(!Operations.isValidDocument(window.activeTextEditor)){
             return;
         }
         if (Operations.isReadOnly(window.activeTextEditor.document)) {

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -21,12 +21,12 @@ export function registerCommands() {
         const options = <QuickPickOptions> {
             placeHolder: "Select Action"
         };
-    
+
         window.showQuickPick(items, options).then(selection => {
             if (typeof selection === "undefined") {
                 return;
             }
-            
+
             if (selection.label === "File Access: Make Read Only") {
                 updateFileAccess(FileAccess.ReadOnly);
             } else {
@@ -34,44 +34,56 @@ export function registerCommands() {
             }
         });
     }
-    
+
     function indicatorAction() {
         const action: string = workspace.getConfiguration("fileAccess").get("indicatorAction");
         switch (action) {
             case "toggle":
-                if (Operations.isReadOnly(window.activeTextEditor.document)) {
-                    updateFileAccess(FileAccess.Writeable);
-                } else {
-                    updateFileAccess(FileAccess.ReadOnly);
-                }
+                toggleFileAccess();
                 break;
-    
+
             case "choose":
                 changeFileAccess();
                 break;
-    
+
             default:
                 console.log(`Received bad action '${action}'`);
                 window.showErrorMessage(`No indicator action '${action}' is available`);
         }
     }
-    
+
+    function toggleFileAccess() {
+        if (!window.activeTextEditor) {
+            window.showInformationMessage("Open a file first to update it attributes");
+            return;
+        }
+        if (Operations.isReadOnly(window.activeTextEditor.document)) {
+            updateFileAccess(FileAccess.Writeable);
+        } else {
+            updateFileAccess(FileAccess.ReadOnly);
+        }
+    }
+
     async function updateFileAccess(fileAccess: FileAccess) {
         if (await Operations.updateFileAccess(fileAccess)) {
             controller.updateStatusBar(fileAccess);
         }
     }
-    
-    commands.registerCommand("readOnly.makeWriteable", () => {        
+
+    commands.registerCommand("readOnly.makeWriteable", () => {
         updateFileAccess(FileAccess.Writeable);
     });
-    
-    commands.registerCommand("readOnly.makeReadOnly", () => {        
+
+    commands.registerCommand("readOnly.makeReadOnly", () => {
         updateFileAccess(FileAccess.ReadOnly);
-    });    
-    
+    });
+
     commands.registerCommand("readOnly.changeFileAccess", () => {
         changeFileAccess();
+    });
+
+    commands.registerCommand("readOnly.toggleFileAccess", () => {
+        toggleFileAccess();
     });
 
     commands.registerCommand("readOnly.indicatorAction", () => {

--- a/src/operations.ts
+++ b/src/operations.ts
@@ -4,7 +4,7 @@
 *--------------------------------------------------------------------------------------------*/
 
 import * as fs from "fs";
-import { TextDocument, window } from "vscode";
+import { TextDocument, TextEditor, window } from "vscode";
 import { FileAccess } from "./constants";
 
 export class Operations {
@@ -13,13 +13,7 @@ export class Operations {
             
         return new Promise<boolean>((resolve, reject) => {
 
-            if (!window.activeTextEditor) {
-                window.showInformationMessage("Open a file first to update it attributes");
-                return resolve (false);
-            }
-            
-            if (window.activeTextEditor.document.uri.scheme === "untitled") {
-                window.showInformationMessage("Save the file first to update it attributes");
+            if(!this.isValidDocument(window.activeTextEditor)){
                 return resolve (false);
             }
             
@@ -81,6 +75,18 @@ export class Operations {
         } catch (error) {
             return true;
         }
+    }
+
+    public static isValidDocument(textEditor: TextEditor | undefined): boolean {
+        if (!textEditor) {
+           window.showInformationMessage("Open a file first to update it attributes");
+           return false;
+        }
+        if (textEditor.document.uri.scheme === "untitled") {
+           window.showInformationMessage("Save the file first to update it attributes");
+           return false;
+        }
+        return true;
     }
 
 }


### PR DESCRIPTION
why:
This change make it possible for toggling of readonly by one action.

Features:
- new command for toggling (this command is same as pull request #11 )
- the above command's shortcut
- change README

This is my first pull request. So, feedback is welcome.