### PR TITLE
Support folder level file access for windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,6 +68,16 @@
 				"enablement": "isWorkspaceTrusted"
 			},
 			{
+				"command": "readOnly.makeWriteableRecursive",
+				"title": "File Access: Make Writeable Recursive",
+				"enablement": "isWorkspaceTrusted"
+			},
+			{
+				"command": "readOnly.makeReadOnlyRecursive",
+				"title": "File Access: Make Read Only Recursive",
+				"enablement": "isWorkspaceTrusted"
+			},
+			{
 				"command": "readOnly.changeFileAccess",
 				"title": "File Access: Change File Access",
 				"enablement": "isWorkspaceTrusted"
@@ -82,6 +92,28 @@
 				"title": "File Access: What's New"
 			}
 		],
+		"menus": {
+			"explorer/context": [
+				{
+					"command": "readOnly.makeReadOnlyRecursive",
+					"when": "isWindows && explorerResourceIsFolder"
+				},
+				{
+					"command": "readOnly.makeWriteableRecursive",
+					"when": "isWindows && explorerResourceIsFolder"
+			  	}
+			],
+			"commandPalette": [
+				{
+					"command": "readOnly.makeReadOnlyRecursive",
+					"when": "false"
+				},
+				{
+					"command": "readOnly.makeWriteableRecursive",
+					"when": "false"
+				}
+			]
+		},
 		"configuration": {
 			"type": "object",
 			"title": "Status Bar Read-Only Indicator Configuration",

--- a/package.json
+++ b/package.json
@@ -68,13 +68,13 @@
 				"enablement": "isWorkspaceTrusted"
 			},
 			{
-				"command": "readOnly.makeWriteableRecursive",
-				"title": "File Access: Make Writeable Recursive",
+				"command": "readOnly.makeWriteableForContextMenu",
+				"title": "Make Writeable",
 				"enablement": "isWorkspaceTrusted"
 			},
 			{
-				"command": "readOnly.makeReadOnlyRecursive",
-				"title": "File Access: Make Read Only Recursive",
+				"command": "readOnly.makeReadOnlyForContextMenu",
+				"title": "Make Read Only",
 				"enablement": "isWorkspaceTrusted"
 			},
 			{
@@ -95,21 +95,21 @@
 		"menus": {
 			"explorer/context": [
 				{
-					"command": "readOnly.makeReadOnlyRecursive",
-					"when": "isWindows && explorerResourceIsFolder"
+					"command": "readOnly.makeReadOnlyForContextMenu",
+					"when": "isWindows"
 				},
 				{
-					"command": "readOnly.makeWriteableRecursive",
-					"when": "isWindows && explorerResourceIsFolder"
+					"command": "readOnly.makeWriteableForContextMenu",
+					"when": "isWindows"
 			  	}
 			],
 			"commandPalette": [
 				{
-					"command": "readOnly.makeReadOnlyRecursive",
+					"command": "readOnly.makeReadOnlyForContextMenu",
 					"when": "false"
 				},
 				{
-					"command": "readOnly.makeWriteableRecursive",
+					"command": "readOnly.makeWriteableForContextMenu",
 					"when": "false"
 				}
 			]

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -3,7 +3,7 @@
 *  Licensed under the MIT License. See License.md in the project root for license information.
 *--------------------------------------------------------------------------------------------*/
 
-import { commands, QuickPickItem, QuickPickOptions, window, workspace } from "vscode";
+import { commands, QuickPickItem, QuickPickOptions, Uri, window, workspace } from "vscode";
 import { FileAccess } from "./constants";
 import { Container } from "./container";
 import { Operations } from "./operations";
@@ -75,6 +75,16 @@ export function registerCommands() {
 
     Container.context.subscriptions.push(commands.registerCommand("readOnly.makeReadOnly", () => {
         updateFileAccess(FileAccess.ReadOnly);
+    }));
+
+    Container.context.subscriptions.push(commands.registerCommand("readOnly.makeWriteableRecursive", (uri?: Uri) => {
+        if(!uri) return;
+        Operations.updateFolderAccess(FileAccess.Writeable, uri);
+    }));
+
+    Container.context.subscriptions.push(commands.registerCommand("readOnly.makeReadOnlyRecursive", (uri?: Uri) => {
+        if(!uri) return;
+        Operations.updateFolderAccess(FileAccess.ReadOnly, uri);
     }));
 
     Container.context.subscriptions.push(commands.registerCommand("readOnly.changeFileAccess", () => {

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -28,9 +28,9 @@ export function registerCommands() {
             }
 
             if (selection.label === "File Access: Make Read Only") {
-                updateFileAccess(FileAccess.ReadOnly);
+                updateEditorFileAccess(FileAccess.ReadOnly);
             } else {
-                updateFileAccess(FileAccess.Writeable);
+                updateEditorFileAccess(FileAccess.Writeable);
             }
         });
     }
@@ -57,28 +57,34 @@ export function registerCommands() {
             return;
         }
         if (Operations.isReadOnly(window.activeTextEditor.document)) {
-            updateFileAccess(FileAccess.Writeable);
+            updateEditorFileAccess(FileAccess.Writeable);
         } else {
-            updateFileAccess(FileAccess.ReadOnly);
+            updateEditorFileAccess(FileAccess.ReadOnly);
         }
     }
 
-    async function updateFileAccess(fileAccess: FileAccess) {
-        if (await Operations.updateFileAccess(fileAccess)) {
+    async function updateEditorFileAccess(fileAccess: FileAccess) {
+        if (await Operations.updateEditorFileAccess(fileAccess)) {
             controller.updateStatusBar(fileAccess);
+        }
+    }
+
+    async function updateFileAccess(fileAccess: FileAccess, uri: Uri) {
+        if (await Operations.updateFileAccess(fileAccess, uri)) {
+            controller.updateStatusBar();
         }
     }
 
     async function updateFolderAccess(fileAccess: FileAccess, uri: Uri) {
         if (await Operations.updateFolderAccess(fileAccess, uri)) {
-            controller.updateStatusBar(fileAccess); 
+            controller.updateStatusBar(); 
         }
     }
 
-    async function updateByFileType(uri: Uri, fileAccess: FileAccess) {
+    async function updateByFileType(fileAccess: FileAccess, uri: Uri) {
         const fileType = Operations.getFileType(uri);
         if(fileType === FileType.File) {
-            updateFileAccess(fileAccess);
+            updateFileAccess(fileAccess, uri);
             return;
         }
         if(fileType === FileType.Directory) {
@@ -94,21 +100,21 @@ export function registerCommands() {
     }
 
     Container.context.subscriptions.push(commands.registerCommand("readOnly.makeWriteable", () => {
-        updateFileAccess(FileAccess.Writeable);
+        updateEditorFileAccess(FileAccess.Writeable);
     }));
 
     Container.context.subscriptions.push(commands.registerCommand("readOnly.makeReadOnly", () => {
-        updateFileAccess(FileAccess.ReadOnly);
+        updateEditorFileAccess(FileAccess.ReadOnly);
     }));
 
     Container.context.subscriptions.push(commands.registerCommand("readOnly.makeWriteableForContextMenu", (uri?: Uri) => {
         if(!uri) return;
-        updateByFileType(uri, FileAccess.Writeable);
+        updateByFileType(FileAccess.Writeable, uri);
     }));
 
     Container.context.subscriptions.push(commands.registerCommand("readOnly.makeReadOnlyForContextMenu", (uri?: Uri) => {
         if(!uri) return;
-        updateByFileType(uri, FileAccess.ReadOnly);
+        updateByFileType(FileAccess.ReadOnly, uri);
     }));
 
     Container.context.subscriptions.push(commands.registerCommand("readOnly.changeFileAccess", () => {

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -69,6 +69,12 @@ export function registerCommands() {
         }
     }
 
+    async function updateFolderAccess(fileAccess: FileAccess, uri: Uri) {
+        if (await Operations.updateFolderAccess(fileAccess, uri)) {
+            controller.updateStatusBar(fileAccess); 
+        }
+    }
+
     Container.context.subscriptions.push(commands.registerCommand("readOnly.makeWriteable", () => {
         updateFileAccess(FileAccess.Writeable);
     }));
@@ -79,12 +85,12 @@ export function registerCommands() {
 
     Container.context.subscriptions.push(commands.registerCommand("readOnly.makeWriteableRecursive", (uri?: Uri) => {
         if(!uri) return;
-        Operations.updateFolderAccess(FileAccess.Writeable, uri);
+        updateFolderAccess(FileAccess.Writeable, uri);
     }));
 
     Container.context.subscriptions.push(commands.registerCommand("readOnly.makeReadOnlyRecursive", (uri?: Uri) => {
         if(!uri) return;
-        Operations.updateFolderAccess(FileAccess.ReadOnly, uri);
+        updateFolderAccess(FileAccess.ReadOnly, uri);
     }));
 
     Container.context.subscriptions.push(commands.registerCommand("readOnly.changeFileAccess", () => {

--- a/src/operations.ts
+++ b/src/operations.ts
@@ -6,7 +6,7 @@
 import * as fs from "fs";
 import * as path from "path";
 import { ChildProcess } from "child_process";
-import { TextDocument, TextEditor, Uri, window } from "vscode";
+import { TextDocument, TextEditor, FileType, Uri, window } from "vscode";
 import { FileAccess } from "./constants";
 
 export class Operations {
@@ -116,6 +116,14 @@ export class Operations {
            return false;
         }
         return true;
+    }
+
+    public static getFileType(uri: Uri): FileType {
+        const stat = fs.statSync(uri.fsPath);
+        if (stat.isFile()) return FileType.File;
+        if (stat.isDirectory()) return FileType.Directory;
+        if (stat.isSymbolicLink()) return FileType.SymbolicLink;
+        return FileType.Unknown;
     }
 
     private static handleSpawnResult(ls: ChildProcess): Promise<boolean> {


### PR DESCRIPTION
#36 

I only have windows, so only implement for it.

Feature:
- Add command to folder context menu on explorer (Not visible in the command palette).
  This command will not appear on except windows.

| selected folder | selected file |
| --- | --- |
|![folder context menu](https://user-images.githubusercontent.com/68765710/123745170-d60c2880-d8ea-11eb-8e39-1301b9019d21.png)|![file context menu](https://user-images.githubusercontent.com/68765710/123745540-634f7d00-d8eb-11eb-847f-7eef8ac985f2.png)|

 - This command makes files in folder read-only/writeable.