### PR TITLE
Support folder level file access for MacOS and Linux

### DIFF
--- a/package.json
+++ b/package.json
@@ -96,11 +96,11 @@
 			"explorer/context": [
 				{
 					"command": "readOnly.makeReadOnlyForContextMenu",
-					"when": "isMac || isWindows"
+					"when": "isMac || isLinux || isWindows"
 				},
 				{
 					"command": "readOnly.makeWriteableForContextMenu",
-					"when": "isMac || isWindows"
+					"when": "isMac || isLinux || isWindows"
 				}
 			],
 			"commandPalette": [

--- a/package.json
+++ b/package.json
@@ -96,11 +96,11 @@
 			"explorer/context": [
 				{
 					"command": "readOnly.makeReadOnlyForContextMenu",
-					"when": "isWindows"
+					"when": "isMac || isWindows"
 				},
 				{
 					"command": "readOnly.makeWriteableForContextMenu",
-					"when": "isWindows"
+					"when": "isMac || isWindows"
 				}
 			],
 			"commandPalette": [

--- a/package.json
+++ b/package.json
@@ -96,11 +96,11 @@
 			"explorer/context": [
 				{
 					"command": "readOnly.makeReadOnlyForContextMenu",
-					"when": "isMac || isLinux || isWindows"
+					"when": "isMac || isWindows"
 				},
 				{
 					"command": "readOnly.makeWriteableForContextMenu",
-					"when": "isMac || isLinux || isWindows"
+					"when": "isMac || isWindows"
 				}
 			],
 			"commandPalette": [

--- a/src/operations.ts
+++ b/src/operations.ts
@@ -54,6 +54,10 @@ export class Operations {
                     attribute = newFileAccess.toString();
                     break;
                 case "linux":
+                    command = "chmod";
+                    // 'u' for user, '-w' for remove write permission
+                    attribute = (newFileAccess === FileAccess.ReadOnly) ? "u-w" : "u+w";
+                    break;
                 case "darwin": /* darwin is the response for macos */
                     command = "chmod";
                     // 'u' for user, '-w' for remove write permission
@@ -97,6 +101,11 @@ export class Operations {
                     args = [attribute, "/s" /* recursive option */, path.join(uri.fsPath, "*.*")];
                     break;
                 case "linux":
+                    command = "chmod";
+                    // 'u' for user, '-w' for remove write permission
+                    attribute = (newFileAccess === FileAccess.ReadOnly) ? "u-w" : "u+w";
+                    args = ["-R" /* flag */, attribute, uri.fsPath];
+                    break;
                 case "darwin": /* darwin is the response for macos */
                     command = "chmod";
                     // 'u' for user, '-w' for remove write permission

--- a/src/operations.ts
+++ b/src/operations.ts
@@ -26,14 +26,14 @@ export class Operations {
                 const activeFileAcessDescription: string = isReadOnly ? "Read-only" : "Writeable";
                 window.showInformationMessage("The file is already " + activeFileAcessDescription);
                 return resolve (false);
-            }  
+            }
 
             return resolve(this.updateFileAccess(newFileAccess, window.activeTextEditor.document.uri));
-        });        
+        });
     }
 
     public static updateFileAccess(newFileAccess: FileAccess, uri: Uri): Promise<boolean> {
-            
+
         return new Promise<boolean>((resolve, reject) => {
 
             try {
@@ -43,7 +43,7 @@ export class Operations {
             } catch (error) {
                 resolve (false);
             }
-            
+
             // determine what operating system we are running on and change the
             // command and arguments used to change the file permissions
             let command;
@@ -70,7 +70,7 @@ export class Operations {
             const ls = spawn(command, [attribute, uri.fsPath]);
 
             resolve(this.handleSpawnResult(ls));
-        });        
+        });
     }
 
     public static updateFolderAccess(newFileAccess: FileAccess, uri: Uri): Promise<boolean> {
@@ -94,22 +94,27 @@ export class Operations {
                 case "win32":
                     command = "attrib";
                     attribute = newFileAccess.toString();
-                    args = ["/s" /* recursive option */, path.join(uri.fsPath, "*.*")];
+                    args = [attribute, "/s" /* recursive option */, path.join(uri.fsPath, "*.*")];
                     break;
                 case "linux":
                 case "darwin": /* darwin is the response for macos */
+                    command = "chmod";
+                    // 'u' for user, '-w' for remove write permission
+                    attribute = (newFileAccess === FileAccess.ReadOnly) ? "u-w" : "u+w";
+                    args = ["-R" /* flag */, attribute, uri.fsPath];
+                    break;
                 default:
                     window.showInformationMessage(
                         "This command is not supported on this system (" + process.platform + ")");
                     return resolve (false);
             }
-            
+
             // eslint-disable-next-line @typescript-eslint/no-var-requires
             const spawn = require("child_process").spawn;
-            const ls = spawn(command, [attribute, ...args]);
+            const ls = spawn(command, args);
 
             resolve(this.handleSpawnResult(ls));
-        });    
+        });
     }
 
     public static isReadOnly(doc: TextDocument): boolean {
@@ -159,8 +164,8 @@ export class Operations {
             ls.on("close", (code) => {
                 console.log(`child process exited with code ${code}`);
                 return resolve(true);
-            });  
-        });  
+            });
+        });
     }
 
 }


### PR DESCRIPTION
close #59

This feature reference #49.

This feature has only been tested on Mac, But the implementation mechanism for Linux is consistent, so try to implement this for Linux.