### PR TITLE
Fix wrong description on readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,8 @@ Writeable |![Writeable](images/screenshot-writeable.png)
 * `Make Read-only`
 * `Make Writeable`
 
-> These commands are available only in Windows
+> **Note**
+> These commands are not available on Linux.
 
 ## Available settings
 


### PR DESCRIPTION
https://github.com/alefragnani/vscode-read-only-indicator/blob/4d951bac56fe8b339cc2790ffeb7b2397b359513/README.md?plain=1#L63

Folder level commands for mac was supported, so above description is wrong.