### PR TITLE
Support vscode readonly

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,11 @@ Writeable |![Writeable](images/screenshot-writeable.png)
     "fileAccess.indicatorAction": "choose" // or "toggle"
     ```
 
+* Sets the save scope of readonlyInclude and readonlyExclude
+    ```json
+    "fileAccess.scope": "workspace" // or "user"
+    ```
+
 ## Available colors
 
 For more information about customizing colors in VSCode, see [Theme Color](https://code.visualstudio.com/api/references/theme-color).

--- a/l10n/bundle.l10n.zh-cn.json
+++ b/l10n/bundle.l10n.zh-cn.json
@@ -1,0 +1,17 @@
+{
+    "Select Action":"选择操作",
+    "No indicator action '{0}' is available":"没有可用的指示器'{0}'操作",
+    "Read-only":"只读",
+    "Writeable":"可写",
+    "Are you sure you want to make files in {0} {1} recursive?":"是否确实要使{0}中的所有文件{1}？",
+    "Make {0}":"设置为{0}",
+    "Cancel":"取消",
+    "The file is already {0}":"该文件已是{0}状态",
+    "This command is not supported on this system ({0})":"此系统（{0}）不支持此命令",
+    "Open a file first to update it attributes":"首先打开文件以更新其属性",
+    "Save the file first to update it attributes":"首先保存文件以更新其属性",
+    "Some error occured: {0}":"出现一些错误：{0}",
+    "child process exited with code {0}":"子进程已退出，代码为{0}",
+    "The file is writeable":"该文件是可写的",
+    "The file is read only":"该文件是只读的"
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
 			"version": "3.9.0",
 			"license": "SEE LICENSE IN LICENSE.md",
 			"dependencies": {
+				"minimatch2": "npm:minimatch@^9.0.3",
 				"vscode-ext-codicons": "^1.0.1"
 			},
 			"devDependencies": {
@@ -828,8 +829,7 @@
 		"node_modules/balanced-match": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-			"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-			"dev": true
+			"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
 		},
 		"node_modules/big-integer": {
 			"version": "1.6.51",
@@ -2289,6 +2289,29 @@
 			},
 			"engines": {
 				"node": "*"
+			}
+		},
+		"node_modules/minimatch2": {
+			"name": "minimatch",
+			"version": "9.0.3",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
+			"integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
+			"dependencies": {
+				"brace-expansion": "^2.0.1"
+			},
+			"engines": {
+				"node": ">=16 || 14 >=14.17"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/minimatch2/node_modules/brace-expansion": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+			"integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+			"dependencies": {
+				"balanced-match": "^1.0.0"
 			}
 		},
 		"node_modules/minimist": {
@@ -4168,8 +4191,7 @@
 		"balanced-match": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-			"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-			"dev": true
+			"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
 		},
 		"big-integer": {
 			"version": "1.6.51",
@@ -5265,6 +5287,24 @@
 			"dev": true,
 			"requires": {
 				"brace-expansion": "^1.1.7"
+			}
+		},
+		"minimatch2": {
+			"version": "npm:minimatch@9.0.3",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
+			"integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
+			"requires": {
+				"brace-expansion": "^2.0.1"
+			},
+			"dependencies": {
+				"brace-expansion": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+					"integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+					"requires": {
+						"balanced-match": "^1.0.0"
+					}
+				}
 			}
 		},
 		"minimist": {

--- a/package.json
+++ b/package.json
@@ -31,14 +31,14 @@
 	"bugs": {
 		"url": "https://github.com/alefragnani/vscode-read-only-indicator/issues"
 	},
-    "sponsor": {
-        "url": "https://github.com/sponsors/alefragnani"
-    },
+	"sponsor": {
+		"url": "https://github.com/sponsors/alefragnani"
+	},
 	"activationEvents": [
 		"onStartupFinished"
 	],
 	"main": "./dist/extension",
-    "l10n": "./l10n",
+	"l10n": "./l10n",
 	"contributes": {
 		"colors": [
 			{
@@ -160,6 +160,15 @@
 						"toggle",
 						"choose"
 					]
+				},
+				"fileAccess.scope": {
+					"type": "string",
+					"default": "workspace",
+					"description": "%fileAccess.configuration.scope.description%",
+					"enum": [
+						"workspace",
+						"user"
+					]
 				}
 			}
 		}
@@ -183,23 +192,24 @@
 		"test": "npm run test-compile && npm run just-test"
 	},
 	"devDependencies": {
+		"@types/glob": "^7.1.4",
+		"@types/mocha": "^9.0.0",
 		"@types/node": "^14.17.27",
-        "@types/vscode": "^1.73.0",
-        "@types/mocha": "^9.0.0",
-        "@types/glob": "^7.1.4",
-        "@vscode/test-electron": "^1.6.2",
+		"@types/vscode": "^1.73.0",
 		"@typescript-eslint/eslint-plugin": "^5.1.0",
 		"@typescript-eslint/parser": "^5.1.0",
+		"@vscode/test-electron": "^1.6.2",
 		"eslint": "^8.1.0",
 		"eslint-config-vscode-ext": "^1.1.0",
+		"mocha": "^9.1.3",
 		"terser-webpack-plugin": "^5.2.4",
 		"ts-loader": "^9.2.5",
 		"typescript": "^4.4.4",
 		"webpack": "^5.76.0",
-		"webpack-cli": "^4.8.0",
-		"mocha": "^9.1.3"
+		"webpack-cli": "^4.8.0"
 	},
 	"dependencies": {
+		"minimatch2": "npm:minimatch@^9.0.3",
 		"vscode-ext-codicons": "^1.0.1"
 	}
 }

--- a/package.nls.json
+++ b/package.nls.json
@@ -4,6 +4,7 @@
     "fileAccess.configuration.uiMode.description": "Define how much information is displayed in the Status Bar indicator",
     "fileAccess.configuration.hideWhenWriteable.description": "Hide the Status Bar indicator when the file is Writeable",
     "fileAccess.configuration.indicatorAction.description": "Sets what action to take when the indicator is clicked",
+    "fileAccess.configuration.scope.description": "Sets the save scope of readonlyInclude and readonlyExclude",
     "fileAccess.colors.readonlyForeground.descripition": "Color for Read Only indicator in the status bar",
     "fileAccess.colors.writeableForeground.descripition": "Color for Writeable indicator in the status bar",
     "readOnly.commands.makeWriteable.title": "File Access: Make Writeable",

--- a/package.nls.pt-br.json
+++ b/package.nls.pt-br.json
@@ -4,6 +4,7 @@
     "fileAccess.configuration.uiMode.description": "Define quanta informação é apresentada no indicador da Barra de Status",
     "fileAccess.configuration.hideWhenWriteable.description": "Esconde o indicador da Barra de Status quando o arquivo é gravável",
     "fileAccess.configuration.indicatorAction.description": "Define qual ação a ser feita quando o indicador é clicado",
+    "fileAccess.configuration.scope.description": "Sets the save scope of readonlyInclude and readonlyExclude",
     "fileAccess.colors.readonlyForeground.descripition": "Cor para o indicador de Somente Leitura na Barra de Status",
     "fileAccess.colors.writeableForeground.descripition": "Cor para o indicador de Gravável na Barra de Status",
     "readOnly.commands.makeWriteable.title": "File Access: Tornar Gravável",

--- a/package.nls.zh-cn.json
+++ b/package.nls.zh-cn.json
@@ -1,0 +1,17 @@
+{
+    "fileAccess.configuration.title": "只读指示器",
+    "fileAccess.configuration.position.description": "定义状态栏指示器的位置",
+    "fileAccess.configuration.uiMode.description": "定义状态栏指示器中显示的信息量",
+    "fileAccess.configuration.hideWhenWriteable.description": "当文件可写时隐藏状态栏指示器",
+    "fileAccess.configuration.indicatorAction.description": "设置单击指示器时要执行的操作",
+    "fileAccess.configuration.scope.description": "设置readonlyInclude和readonlyExclude的保存范围",
+    "fileAccess.colors.readonlyForeground.descripition": "状态栏中只读指示器的颜色",
+    "fileAccess.colors.writeableForeground.descripition": "状态库中可写指示器的颜色r",
+    "readOnly.commands.makeWriteable.title": "文件访问指示器: 设置为可写",
+    "readOnly.commands.makeReadOnly.title": "文件访问指示器: 设置为只读",
+    "readOnly.commands.makeWriteableForContextMenu.title": "设置为可写",
+    "readOnly.commands.makeReadOnlyForContextMenu.title": "设置为只读",
+    "readOnly.commands.changeFileAccess.title": "文件访问指示器: 更改文件访问权限",
+    "readOnly.commands.toggleFileAccess.title": "文件访问指示器: 切换文件访问",
+    "readOnly.commands.whatsNew.title": "文件访问指示器: 新功能"
+}

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -1,7 +1,7 @@
 /*---------------------------------------------------------------------------------------------
-*  Copyright (c) Alessandro Fragnani. All rights reserved.
-*  Licensed under the MIT License. See License.md in the project root for license information.
-*--------------------------------------------------------------------------------------------*/
+ *  Copyright (c) Alessandro Fragnani. All rights reserved.
+ *  Licensed under the MIT License. See License.md in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
 
 import { commands, FileType, l10n, QuickPickItem, QuickPickOptions, Uri, window, workspace } from "vscode";
 import { FileAccess } from "./constants";
@@ -10,7 +10,6 @@ import { Operations } from "./operations";
 import { Controller } from "./statusBar/controller";
 
 export function registerCommands() {
-
     const controller = new Controller();
     Container.context.subscriptions.push(controller);
 
@@ -18,11 +17,11 @@ export function registerCommands() {
         const items: QuickPickItem[] = [];
         items.push({ label: "File Access: Make Read Only", description: "" });
         items.push({ label: "File Access: Make Writeable", description: "" });
-        const options = <QuickPickOptions> {
-            placeHolder: l10n.t("Select Action")
+        const options = <QuickPickOptions>{
+            placeHolder: l10n.t("Select Action"),
         };
 
-        window.showQuickPick(items, options).then(selection => {
+        window.showQuickPick(items, options).then((selection) => {
             if (typeof selection === "undefined") {
                 return;
             }
@@ -53,7 +52,7 @@ export function registerCommands() {
     }
 
     function toggleFileAccess() {
-        if(!Operations.isValidDocument(window.activeTextEditor)){
+        if (!Operations.isValidDocument(window.activeTextEditor)) {
             return;
         }
         if (Operations.isReadOnly(window.activeTextEditor.document)) {
@@ -71,63 +70,76 @@ export function registerCommands() {
 
     async function updateFileAccess(fileAccess: FileAccess, uri: Uri) {
         if (await Operations.updateFileAccess(fileAccess, uri)) {
-            controller.updateStatusBar();
+            controller.updateStatusBar(fileAccess);
         }
     }
 
     async function updateFolderAccess(fileAccess: FileAccess, uri: Uri) {
         if (await Operations.updateFolderAccess(fileAccess, uri)) {
-            controller.updateStatusBar(); 
+            controller.updateStatusBar(fileAccess);
         }
     }
 
     async function updateByFileType(fileAccess: FileAccess, uri: Uri) {
         const fileType = Operations.getFileType(uri);
-        if(fileType === FileType.File) {
+        if (fileType === FileType.File) {
             updateFileAccess(fileAccess, uri);
             return;
         }
-        if(fileType === FileType.Directory) {
-            const fileAccessDescription: string = fileAccess === FileAccess.ReadOnly 
-                ? l10n.t("Read-only") 
-                : l10n.t("Writeable");
+        if (fileType === FileType.Directory) {
+            const fileAccessDescription: string =
+                fileAccess === FileAccess.ReadOnly ? l10n.t("Read-only") : l10n.t("Writeable");
             const userSelection = await window.showInformationMessage(
                 l10n.t("Are you sure you want to make files in {0} {1} recursive?", uri.fsPath, fileAccessDescription),
                 l10n.t("Make {0}", fileAccessDescription),
                 l10n.t("Cancel")
             );
-            if(userSelection === l10n.t("Cancel")) return;
+            if (userSelection === l10n.t("Cancel")) return;
             updateFolderAccess(fileAccess, uri);
         }
     }
 
-    Container.context.subscriptions.push(commands.registerCommand("readOnly.makeWriteable", () => {
-        updateEditorFileAccess(FileAccess.Writeable);
-    }));
+    Container.context.subscriptions.push(
+        commands.registerCommand("readOnly.makeWriteable", () => {
+            updateEditorFileAccess(FileAccess.Writeable);
+        })
+    );
 
-    Container.context.subscriptions.push(commands.registerCommand("readOnly.makeReadOnly", () => {
-        updateEditorFileAccess(FileAccess.ReadOnly);
-    }));
+    Container.context.subscriptions.push(
+        commands.registerCommand("readOnly.makeReadOnly", () => {
+            updateEditorFileAccess(FileAccess.ReadOnly);
+        })
+    );
 
-    Container.context.subscriptions.push(commands.registerCommand("readOnly.makeWriteableForContextMenu", (uri?: Uri) => {
-        if(!uri) return;
-        updateByFileType(FileAccess.Writeable, uri);
-    }));
+    Container.context.subscriptions.push(
+        commands.registerCommand("readOnly.makeWriteableForContextMenu", (uri?: Uri) => {
+            if (!uri) return;
+            updateByFileType(FileAccess.Writeable, uri);
+        })
+    );
 
-    Container.context.subscriptions.push(commands.registerCommand("readOnly.makeReadOnlyForContextMenu", (uri?: Uri) => {
-        if(!uri) return;
-        updateByFileType(FileAccess.ReadOnly, uri);
-    }));
+    Container.context.subscriptions.push(
+        commands.registerCommand("readOnly.makeReadOnlyForContextMenu", (uri?: Uri) => {
+            if (!uri) return;
+            updateByFileType(FileAccess.ReadOnly, uri);
+        })
+    );
 
-    Container.context.subscriptions.push(commands.registerCommand("readOnly.changeFileAccess", () => {
-        changeFileAccess();
-    }));
+    Container.context.subscriptions.push(
+        commands.registerCommand("readOnly.changeFileAccess", () => {
+            changeFileAccess();
+        })
+    );
 
-    Container.context.subscriptions.push(commands.registerCommand("readOnly.toggleFileAccess", () => {
-        toggleFileAccess();
-    }));
+    Container.context.subscriptions.push(
+        commands.registerCommand("readOnly.toggleFileAccess", () => {
+            toggleFileAccess();
+        })
+    );
 
-    Container.context.subscriptions.push(commands.registerCommand("readOnly.indicatorAction", () => {
-        indicatorAction();
-    }));
+    Container.context.subscriptions.push(
+        commands.registerCommand("readOnly.indicatorAction", () => {
+            indicatorAction();
+        })
+    );
 }

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -3,12 +3,17 @@
 *  Licensed under the MIT License. See License.md in the project root for license information.
 *--------------------------------------------------------------------------------------------*/
 
+export const enum Scope {
+    Workspace,
+    User
+}
+
 export const enum UIMode {
     Complete,
     Simple
 }
 
 export const enum FileAccess {
-    ReadOnly = "+R",
-    Writeable = "-R"
+    ReadOnly = "Read-only",
+    Writeable = "Writeable"
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,15 +1,14 @@
 /*---------------------------------------------------------------------------------------------
-*  Copyright (c) Alessandro Fragnani. All rights reserved.
-*  Licensed under the MIT License. See License.md in the project root for license information.
-*--------------------------------------------------------------------------------------------*/
+ *  Copyright (c) Alessandro Fragnani. All rights reserved.
+ *  Licensed under the MIT License. See License.md in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
 
 import { ExtensionContext } from "vscode";
 import { registerCommands } from "./commands";
 import { Container } from "./container";
 import { registerWhatsNew } from "./whats-new/command";
 
-export async function activate(ctx: ExtensionContext) { 
-
+export async function activate(ctx: ExtensionContext) {
     Container.context = ctx;
 
     await registerWhatsNew();

--- a/src/statusBar/controller.ts
+++ b/src/statusBar/controller.ts
@@ -1,7 +1,7 @@
 /*---------------------------------------------------------------------------------------------
-*  Copyright (c) Alessandro Fragnani. All rights reserved.
-*  Licensed under the MIT License. See License.md in the project root for license information.
-*--------------------------------------------------------------------------------------------*/
+ *  Copyright (c) Alessandro Fragnani. All rights reserved.
+ *  Licensed under the MIT License. See License.md in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
 
 import { Disposable, window, workspace } from "vscode";
 import { FileAccess } from "./../constants";
@@ -18,28 +18,36 @@ export class Controller {
 
         Container.context.subscriptions.push(this.statusBar);
 
-        window.onDidChangeActiveTextEditor(() => {
-            this.statusBar.update();
-        }, null, Container.context.subscriptions);
+        window.onDidChangeActiveTextEditor(
+            () => {
+                this.statusBar.update();
+            },
+            null,
+            Container.context.subscriptions
+        );
 
-        workspace.onDidChangeConfiguration(cfg => {
-            if (cfg.affectsConfiguration("fileAccess.position")) {
-                this.statusBar.dispose();
-                this.statusBar = undefined;
-                
-                this.statusBar = new StatusBar();
-            }
-            if (cfg.affectsConfiguration("fileAccess")) {
-                this.updateStatusBar();
-            }
-        }, null, Container.context.subscriptions);
+        workspace.onDidChangeConfiguration(
+            (cfg) => {
+                if (cfg.affectsConfiguration("fileAccess.position")) {
+                    this.statusBar.dispose();
+                    this.statusBar = undefined;
+
+                    this.statusBar = new StatusBar();
+                }
+                if (cfg.affectsConfiguration("fileAccess")) {
+                    this.updateStatusBar();
+                }
+            },
+            null,
+            Container.context.subscriptions
+        );
 
         workspace.onDidGrantWorkspaceTrust(() => {
             this.statusBar.dispose();
             this.statusBar = undefined;
-            
+
             this.statusBar = new StatusBar();
-        })
+        });
     }
 
     public dispose() {

--- a/src/statusBar/statusBar.ts
+++ b/src/statusBar/statusBar.ts
@@ -1,7 +1,7 @@
 /*---------------------------------------------------------------------------------------------
-*  Copyright (c) Alessandro Fragnani. All rights reserved.
-*  Licensed under the MIT License. See License.md in the project root for license information.
-*--------------------------------------------------------------------------------------------*/
+ *  Copyright (c) Alessandro Fragnani. All rights reserved.
+ *  Licensed under the MIT License. See License.md in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
 
 import { l10n, StatusBarAlignment, StatusBarItem, ThemeColor, window, workspace } from "vscode";
 import { FileAccess, UIMode } from "./../constants";
@@ -12,13 +12,13 @@ export class StatusBar {
     private statusBarItem: StatusBarItem;
 
     constructor() {
-        const locationString: string = (workspace.getConfiguration("fileAccess").get("position", "left"));
-        const location: StatusBarAlignment = locationString === "left" ?
-            StatusBarAlignment.Left : StatusBarAlignment.Right;
-        
+        const locationString: string = workspace.getConfiguration("fileAccess").get("position", "left");
+        const location: StatusBarAlignment =
+            locationString === "left" ? StatusBarAlignment.Left : StatusBarAlignment.Right;
+
         this.statusBarItem = window.createStatusBarItem("fileAccess.statusBar", location);
         this.statusBarItem.name = "File Access";
-        if (workspace.isTrusted) { 
+        if (workspace.isTrusted) {
             this.statusBarItem.command = "readOnly.indicatorAction";
         }
     }
@@ -28,12 +28,11 @@ export class StatusBar {
     }
 
     public update(fileAccess?: FileAccess) {
-        
         if (!window.activeTextEditor) {
             this.statusBarItem.hide();
             return;
         }
-        
+
         const activeDocument = window.activeTextEditor.document;
         if (activeDocument.isUntitled) {
             this.statusBarItem.hide();
@@ -41,23 +40,21 @@ export class StatusBar {
         }
 
         // ui
-        const uimodeString: string = (workspace.getConfiguration("fileAccess").get("uiMode", "complete"));
+        const uimodeString: string = workspace.getConfiguration("fileAccess").get("uiMode", "complete");
         const uimode: UIMode = uimodeString === "complete" ? UIMode.Complete : UIMode.Simple;
         const readOnly = fileAccess ? fileAccess === FileAccess.ReadOnly : Operations.isReadOnly(activeDocument);
 
         // Update the status bar
         if (uimode === UIMode.Complete) {
-            this.statusBarItem.text = !readOnly ? codicons.pencil + " [RW]" : codicons.circle_slash + " [RO]";
+            this.statusBarItem.text = !readOnly ? codicons.unlock + " [RW]" : codicons.lock + " [RO]";
         } else {
             this.statusBarItem.text = !readOnly ? "RW" : "RO";
         }
-        this.statusBarItem.color = new ThemeColor(readOnly 
-                                    ? "fileAccess.readonlyForeground" 
-                                    : "fileAccess.writeableForeground");
+        this.statusBarItem.color = new ThemeColor(
+            readOnly ? "fileAccess.readonlyForeground" : "fileAccess.writeableForeground"
+        );
 
-        this.statusBarItem.tooltip = !readOnly 
-            ? l10n.t("The file is writeable") 
-            : l10n.t("The file is read only");
+        this.statusBarItem.tooltip = !readOnly ? l10n.t("The file is writeable") : l10n.t("The file is read only");
 
         // Show or hide the status bar indicator as appropriate
         const show = readOnly || !workspace.getConfiguration("fileAccess").get("hideWhenWriteable", false);


### PR DESCRIPTION
Support vscode readonly

    1. Remove code that previously modified file or folder permissions
    2. Add Chinese localization
    3. Change rw and ro icons

Close #89.

Tested on mac, windows, linux and vscode ssh remote.

In this way, the operation of modifying file permissions is removed, and the read-only mode of vscode is supported.

Now when you click the status bar to modify permissions, `files.readonlyInclude` and `files.readonlyExculde` of vscode will be used, and these two objects will be saved to `.vscode/settings.json` in the `workspace` by default for next use.

icons:
<img width="72" alt="image" src="https://github.com/alefragnani/vscode-read-only-indicator/assets/17561793/ed04fff7-e0ce-4029-9359-0694a2d4d6e2"><img width="71" alt="image" src="https://github.com/alefragnani/vscode-read-only-indicator/assets/17561793/8caa727f-e9d3-4b10-8463-515b06c05e09">

settings.json:
<img width="1180" alt="image" src="https://github.com/alefragnani/vscode-read-only-indicator/assets/17561793/6a26965d-7a22-452f-8b5c-90a263dbdd00">
